### PR TITLE
Add VibeXP CLI to homebrew tap

### DIFF
--- a/Formula/vibexp.rb
+++ b/Formula/vibexp.rb
@@ -1,0 +1,49 @@
+# typed: false
+# frozen_string_literal: true
+
+class Vibexp < Formula
+  desc "VibeXP CLI - Command line interface for the VibeXP platform"
+  homepage "https://github.com/shaharia-lab/vibexp.io"
+  version "0.3.2"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/shaharia-lab/vibexp.io/releases/download/cli-v0.3.2/vibexp-darwin-x64"
+      sha256 "23e4c28aee2fdb5d83ef2e620794c8488464001fd55e68979657fb14e3287f21"
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/shaharia-lab/vibexp.io/releases/download/cli-v0.3.2/vibexp-darwin-arm64"
+      sha256 "825f0987962ff57d744d5d10a3b28be3c072e9645be00607dd37f8f78cbe0f08"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/shaharia-lab/vibexp.io/releases/download/cli-v0.3.2/vibexp-linux-x64"
+        sha256 "255a70899b71422f30df69d48965314abdf3d9747d0ba033315a9aad9029da35"
+      end
+    end
+    if Hardware::CPU.arm?
+      if Hardware::CPU.is_64_bit?
+        url "https://github.com/shaharia-lab/vibexp.io/releases/download/cli-v0.3.2/vibexp-linux-arm64"
+        sha256 "dcb8e22d881552f147ba5d6a875e7c79ecd8c2b3020960357f56bfe83262d62f"
+      end
+    end
+  end
+
+  def install
+    # The binary is downloaded directly (not in an archive)
+    # Rename the platform-specific binary to 'vibexp'
+    downloaded_file = Dir.glob("vibexp-*").first
+    if downloaded_file && File.exist?(downloaded_file)
+      mv downloaded_file, "vibexp"
+    end
+    bin.install "vibexp"
+  end
+
+  test do
+    system "#{bin}/vibexp", "--version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ brew tap shaharia-lab/tap
 brew install codenav
 brew install gscli
 brew install slackcli
+brew install vibexp
 ```
 
 ## Available Formulas
@@ -22,6 +23,7 @@ brew install slackcli
 | `gscli` | Google Suite CLI - Access Gmail, Drive, and Calendar from command line | [gscli](https://github.com/shaharia-lab/gscli) |
 | `slackcli` | Slack CLI - Interact with Slack from command line | [slackcli](https://github.com/shaharia-lab/slackcli) |
 | `echoy` | Intelligent & smart AI assistance for your daily life | [echoy](https://github.com/shaharia-lab/echoy) |
+| `vibexp` | VibeXP CLI - Command line interface for the VibeXP platform | [vibexp.io](https://github.com/shaharia-lab/vibexp.io) |
 
 ## Installation Methods
 
@@ -35,6 +37,7 @@ brew tap shaharia-lab/tap
 brew install codenav
 brew install gscli
 brew install slackcli
+brew install vibexp
 ```
 
 ### Alternative: Direct install (no tap setup needed)
@@ -44,6 +47,7 @@ brew install slackcli
 brew install shaharia-lab/tap/codenav
 brew install shaharia-lab/tap/gscli
 brew install shaharia-lab/tap/slackcli
+brew install shaharia-lab/tap/vibexp
 ```
 
 ## Platform Support


### PR DESCRIPTION
## Summary

This PR adds the VibeXP CLI formula to the homebrew tap, enabling users to install VibeXP CLI via Homebrew.

## Changes

- ✅ Add `Formula/vibexp.rb` for version 0.3.2
- ✅ Platform support: macOS (Intel & Apple Silicon), Linux (x64 & ARM64)
- ✅ Update README.md with VibeXP CLI installation instructions
- ✅ SHA256 checksums verified for all platforms

## Installation

After this PR is merged, users can install VibeXP CLI with:

```bash
brew tap shaharia-lab/tap
brew install vibexp
```

Or directly:
```bash
brew install shaharia-lab/tap/vibexp
```

## Testing

- [ ] Formula tested on macOS Apple Silicon
- [ ] Formula tested on macOS Intel
- [ ] Formula tested on Linux x64

## Related

- Part of issue shaharia-lab/vibexp.io#501
- Follows the same pattern as codenav and gscli formulas
- Automation workflow will be added to vibexp.io repository separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)